### PR TITLE
fix json conversion functions on clojurescript

### DIFF
--- a/jar/src/cljc/sixsq/slipstream/client/api/impl/cimi.cljc
+++ b/jar/src/cljc/sixsq/slipstream/client/api/impl/cimi.cljc
@@ -44,14 +44,11 @@
 
 (defn str->json [s]
   #?(:clj  (json/read-str s :key-fn keyword)
-     :cljs (js->clj (JSON.parse s) {:keywordize-keys true})))
-
-(defn kw->string [kw]
-  (if (keyword? kw) (name kw) kw))
+     :cljs (js->clj (JSON.parse s) :keywordize-keys true)))
 
 (defn edn->json [json]
   #?(:clj  (json/write-str json)
-     :cljs (JSON.stringify (w/postwalk kw->string json))))
+     :cljs (JSON.stringify (clj->js json))))
 
 (defn json->edn [s]
   (cond

--- a/jar/src/cljc/sixsq/slipstream/client/api/impl/cimi.cljc
+++ b/jar/src/cljc/sixsq/slipstream/client/api/impl/cimi.cljc
@@ -6,9 +6,7 @@
   (:require
     [sixsq.slipstream.client.api.utils.http-sync :as http]  ;; FIXME: Wrong library included.
     [sixsq.slipstream.client.api.utils.error :as e]
-    [clojure.walk :as w]
-    #?(:clj [clojure.data.json :as json])
-    [superstring.core :as s]))
+    #?(:clj [clojure.data.json :as json])))
 
 (def action-uris {:add    "http://sixsq.com/slipstream/1/Action/add"
                   :delete "http://sixsq.com/slipstream/1/Action/delete"

--- a/jar/test/cljc/sixsq/slipstream/client/api/impl/cimi_test.cljc
+++ b/jar/test/cljc/sixsq/slipstream/client/api/impl/cimi_test.cljc
@@ -40,7 +40,7 @@
              "https://localhost:8201/api/service-info" "service-info"
              "https://localhost:8201/api/usage-record" "usage-records"))
 
-(defn body-tests [f]
+(defn body-tests [done]
   (go
     (let [body {:alpha 1
                 :beta  "2"
@@ -51,13 +51,13 @@
           _ (>! c {:body json})
           result (<! c)]
       (is (= body result)))
-    (if f (f))))
+    (if done (done))))
 
 (deftest check-body-as-json
   #?(:clj (<!! (body-tests nil))
      :cljs (async done (body-tests done))))
 
-(defn exception-tests [f]
+(defn exception-tests [done]
   (go
     (let [msg "msg-to-match"
           data {:dummy "data"}
@@ -69,7 +69,7 @@
       (is (= msg #?(:clj (.getMessage result)
                     :cljs (.-message result))))
       (is (= data (ex-data result))))
-    (if f (f))))
+    (if done (done))))
 
 (deftest check-body-as-json-error
   #?(:clj (<!! (exception-tests nil))

--- a/jar/test/cljc/sixsq/slipstream/client/api/impl/cimi_test.cljc
+++ b/jar/test/cljc/sixsq/slipstream/client/api/impl/cimi_test.cljc
@@ -40,7 +40,7 @@
              "https://localhost:8201/api/service-info" "service-info"
              "https://localhost:8201/api/usage-record" "usage-records"))
 
-(defn body-tests []
+(defn body-tests [f]
   (go
     (let [body {:alpha 1
                 :beta  "2"
@@ -50,13 +50,14 @@
           c (chan 1 (t/body-as-json) identity)
           _ (>! c {:body json})
           result (<! c)]
-      (is (= body result)))))
+      (is (= body result)))
+    (if f (f))))
 
 (deftest check-body-as-json
-  #?(:clj (<!! (body-tests))
-     :cljs (async done (body-tests) (done))))
+  #?(:clj (<!! (body-tests nil))
+     :cljs (async done (body-tests done))))
 
-(defn exception-tests []
+(defn exception-tests [f]
   (go
     (let [msg "msg-to-match"
           data {:dummy "data"}
@@ -67,9 +68,10 @@
       (is (e/error? result))
       (is (= msg #?(:clj (.getMessage result)
                     :cljs (.-message result))))
-      (is (= data (ex-data result))))))
+      (is (= data (ex-data result))))
+    (if f (f))))
 
 (deftest check-body-as-json-error
-  #?(:clj (<!! (exception-tests))
-     :cljs (async done (exception-tests) (done))))
+  #?(:clj (<!! (exception-tests nil))
+     :cljs (async done (exception-tests done))))
 

--- a/jar/test/cljc/sixsq/slipstream/client/api/impl/cimi_test.cljc
+++ b/jar/test/cljc/sixsq/slipstream/client/api/impl/cimi_test.cljc
@@ -40,38 +40,43 @@
              "https://localhost:8201/api/service-info" "service-info"
              "https://localhost:8201/api/usage-record" "usage-records"))
 
-(defn body-tests [done]
-  (go
-    (let [body {:alpha 1
-                :beta  "2"
-                :gamma 3.0
-                :delta false}
-          json (t/edn->json body)
-          c (chan 1 (t/body-as-json) identity)
-          _ (>! c {:body json})
-          result (<! c)]
-      (is (= body result)))
-    (if done (done))))
+(defn body-tests
+  ([]
+    (body-tests nil))
+  ([done]
+   (go
+     (let [body {:alpha 1
+                 :beta  "2"
+                 :gamma 3.0
+                 :delta false}
+           json (t/edn->json body)
+           c (chan 1 (t/body-as-json) identity)
+           _ (>! c {:body json})
+           result (<! c)]
+       (is (= body result)))
+     (if done (done)))))
 
 (deftest check-body-as-json
-  #?(:clj (<!! (body-tests nil))
+  #?(:clj (<!! (body-tests))
      :cljs (async done (body-tests done))))
 
-(defn exception-tests [done]
-  (go
-    (let [msg "msg-to-match"
-          data {:dummy "data"}
-          ex (ex-info msg data)
-          c (chan 1 (t/body-as-json) identity)
-          _ (>! c ex)
-          result (<! c)]
-      (is (e/error? result))
-      (is (= msg #?(:clj (.getMessage result)
-                    :cljs (.-message result))))
-      (is (= data (ex-data result))))
-    (if done (done))))
+(defn exception-tests
+  ([]
+    (exception-tests nil))
+  ([done]
+   (go
+     (let [msg "msg-to-match"
+           data {:dummy "data"}
+           ex (ex-info msg data)
+           c (chan 1 (t/body-as-json) identity)
+           _ (>! c ex)
+           result (<! c)]
+       (is (e/error? result))
+       (is (= msg #?(:clj  (.getMessage result)
+                     :cljs (.-message result))))
+       (is (= data (ex-data result))))
+     (if done (done)))))
 
 (deftest check-body-as-json-error
-  #?(:clj (<!! (exception-tests nil))
+  #?(:clj (<!! (exception-tests))
      :cljs (async done (exception-tests done))))
-


### PR DESCRIPTION
Connected to #45.  

Correct the unit tests so that they are run with both clojure and clojurescript.  Correct the json conversion functions, ensuring that the right options and functions are used.
