### PR TITLE
add wait for provisioning state

### DIFF
--- a/cimi/src/clj/sixsq/slipstream/client/run.clj
+++ b/cimi/src/clj/sixsq/slipstream/client/run.clj
@@ -222,6 +222,13 @@
   [comp ids]
   (r/scale-down (run-uuid) comp ids))
 
+(defn wait-provisioning
+  "Waits for Provisioning state on the run. Returns true on success."
+  ([]
+   (r/wait-provisioning (run-uuid)))
+  ([timeout]
+   (r/wait-provisioning (run-uuid) timeout)))
+
 (defn wait-ready
   "Waits for Ready state on the run. Returns true on success."
   ([]

--- a/cimi/src/clj/sixsq/slipstream/client/run_impl/lib/run.clj
+++ b/cimi/src/clj/sixsq/slipstream/client/run_impl/lib/run.clj
@@ -210,6 +210,14 @@
   (log/debug "Waiting for" state "state for" timeout "sec.")
   (wu/wait-for #(= state (get-state run-uuid)) timeout interval))
 
+(defn wait-provisioning
+  "Waits for Provisioning state on the run. Returns true on success."
+  ([run-uuid]
+   (wait-state run-uuid "Provisioning" :timeout wait-timeout-default :interval 5))
+  ([run-uuid timeout]
+   (wait-state run-uuid "Provisioning" :timeout timeout :interval 5)))
+
+
 (defn wait-ready
   "Waits for Ready state on the run. Returns true on success."
   ([run-uuid]


### PR DESCRIPTION
Needed when running scaling tests to avoid hopping over the provisioning state and proceeding too early. 